### PR TITLE
Add gasPrice parameter to MoxieWalletClient

### DIFF
--- a/packages/moxie-lib/src/wallet.ts
+++ b/packages/moxie-lib/src/wallet.ts
@@ -102,6 +102,7 @@ export class MoxieWalletClient {
             value: transactionDetails.value,
             data: transactionDetails.data,
             gasLimit: transactionDetails.gasLimit,
+            gasPrice: transactionDetails.gasPrice,
             maxFeePerGas: transactionDetails.maxFeePerGas,
             maxPriorityFeePerGas: transactionDetails.maxPriorityFeePerGas,
         });


### PR DESCRIPTION
# Background

The gas price wasn't passed to the transaction.

# PR Category

- [x] Bug Fixes (non-breaking change which fixes an issue)
    - [x] Low

# Description

Passing the `gasPrice` parameter to the Signer's `sendTransaction`