### PR TITLE
Add GroupParams and ManageGroupsError type definition to Fix hallucinations on the data structure

### DIFF
--- a/packages/plugin-moxie-groups/src/templates.ts
+++ b/packages/plugin-moxie-groups/src/templates.ts
@@ -68,6 +68,25 @@ Instructions:
    }
    \`\`\`
 
+   where "GroupParams" is defined as:
+
+   \`\`\`json
+   {
+     "groupId": string | undefined,
+     "groupName": string | undefined,
+     "senpiUserIdsToAdd": string[] | undefined,
+     "senpiUserIdsToRemove": string[] | undefined
+   }
+   \`\`\`
+
+   and "ManageGroupsError" is defined as:
+   \`\`\`json
+   {
+     "missingFields": string[],
+     "message": string
+   }
+   \`\`\`
+
 6. Error Handling:
    If the action cannot be determined, invalid combinations are provided, or required parameters are missing, return an error response with a list of missing fields and a prompt message.
 


### PR DESCRIPTION
# Issue

Sometimes the JSON returned are not based on the GroupParams and ManageGroupsError data structure defined since the template does not clarify this, causing sometimes field names to be wrong, e.g. `groupName` becomes `newGroupName` when updating.

By adding these definitions explicitly, this should solve the issue.